### PR TITLE
Remove unused dependencies on forgerock-eidas-psd2-sdk-cert

### DIFF
--- a/forgerock-openbanking-jwkms-client/pom.xml
+++ b/forgerock-openbanking-jwkms-client/pom.xml
@@ -63,8 +63,8 @@
             <artifactId>jackson-datatype-joda</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.forgerock</groupId>
-            <artifactId>forgerock-eidas-psd2-cert-sdk</artifactId>
+            <groupId>com.forgerock.openbanking</groupId>
+            <artifactId>forgerock-openbanking-ssl</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-parent</artifactId>
-        <version>1.0.57</version>
+        <version>1.0.60</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 


### PR DESCRIPTION
- This has now moved and there is no dependency mangement declaration in
the lastest parent pom meaning this would fail to build when using the
latest parent poms unless these dependencies are removed