### PR TITLE
Release/1.0.44

### DIFF
--- a/forgerock-openbanking-analytics-client/pom.xml
+++ b/forgerock-openbanking-analytics-client/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.clients</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-clients</artifactId>
-        <version>1.0.44</version>
+        <version>1.0.45-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-analytics-client/pom.xml
+++ b/forgerock-openbanking-analytics-client/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.clients</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-clients</artifactId>
-        <version>1.0.44-SNAPSHOT</version>
+        <version>1.0.44</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-analytics-webclient/pom.xml
+++ b/forgerock-openbanking-analytics-webclient/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <artifactId>forgerock-openbanking-reference-implementation-clients</artifactId>
         <groupId>com.forgerock.openbanking.clients</groupId>
-        <version>1.0.44-SNAPSHOT</version>
+        <version>1.0.44</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-analytics-webclient/pom.xml
+++ b/forgerock-openbanking-analytics-webclient/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <artifactId>forgerock-openbanking-reference-implementation-clients</artifactId>
         <groupId>com.forgerock.openbanking.clients</groupId>
-        <version>1.0.44</version>
+        <version>1.0.45-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-client/pom.xml
+++ b/forgerock-openbanking-jwkms-client/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.clients</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-clients</artifactId>
-        <version>1.0.44</version>
+        <version>1.0.45-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-client/pom.xml
+++ b/forgerock-openbanking-jwkms-client/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.clients</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-clients</artifactId>
-        <version>1.0.44-SNAPSHOT</version>
+        <version>1.0.44</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - Clients</name>
     <groupId>com.forgerock.openbanking.clients</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-clients</artifactId>
-    <version>1.0.44</version>
+    <version>1.0.45-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -94,7 +94,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-clients.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-clients.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-clients.git</url>
-        <tag>1.0.44</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - Clients</name>
     <groupId>com.forgerock.openbanking.clients</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-clients</artifactId>
-    <version>1.0.44-SNAPSHOT</version>
+    <version>1.0.44</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -94,7 +94,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-clients.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-clients.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-clients.git</url>
-        <tag>HEAD</tag>
+        <tag>1.0.44</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <url>http://www.forgerock.org</url>
 
     <properties>
-        <ob-common.version>1.0.84</ob-common.version>
+        <ob-common.version>1.0.86</ob-common.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Release 1.0.44
- Bumped [openbanking-common](https://github.com/OpenBankingToolkit/openbanking-common) release [version 1.0.86](https://github.com/OpenBankingToolkit/openbanking-common/releases/tag/1.0.86)
  - Added a MongoRepository `TppRepository`  class to get/store `Tpp objects`
- Prepare for the next development iteration.