### PR TITLE
793: Can serialise OpenBanking software statements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <url>http://www.forgerock.org</url>
 
     <properties>
-        <ob-common.version>1.2.6</ob-common.version>
+        <ob-common.version>1.2.7</ob-common.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Use v 1.2.7 of openbanking commons 
https://github.com/OpenBankingToolkit/openbanking-common/releases/tag/1.2.7

Fixes;
Serialisation is based on the value of the `iss` field of the software
statement, and the code expected OpenBanking iss to be "OpenBanking",
however in OB Directory Issued Software Statements the iss field is
actually "OpenBanking Ltd"

Issue: https://github.com/ForgeCloud/ob-deploy/issues/793