### PR TITLE
Release 1.2.7

### DIFF
--- a/forgerock-openbanking-analytics-client/pom.xml
+++ b/forgerock-openbanking-analytics-client/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.clients</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-clients</artifactId>
-        <version>1.2.7-SNAPSHOT</version>
+        <version>1.2.7</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-analytics-client/pom.xml
+++ b/forgerock-openbanking-analytics-client/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.clients</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-clients</artifactId>
-        <version>1.2.7</version>
+        <version>1.2.8-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-analytics-webclient/pom.xml
+++ b/forgerock-openbanking-analytics-webclient/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <artifactId>forgerock-openbanking-reference-implementation-clients</artifactId>
         <groupId>com.forgerock.openbanking.clients</groupId>
-        <version>1.2.7-SNAPSHOT</version>
+        <version>1.2.7</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-analytics-webclient/pom.xml
+++ b/forgerock-openbanking-analytics-webclient/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <artifactId>forgerock-openbanking-reference-implementation-clients</artifactId>
         <groupId>com.forgerock.openbanking.clients</groupId>
-        <version>1.2.7</version>
+        <version>1.2.8-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-client/pom.xml
+++ b/forgerock-openbanking-jwkms-client/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.clients</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-clients</artifactId>
-        <version>1.2.7-SNAPSHOT</version>
+        <version>1.2.7</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-client/pom.xml
+++ b/forgerock-openbanking-jwkms-client/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.clients</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-clients</artifactId>
-        <version>1.2.7</version>
+        <version>1.2.8-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - Clients</name>
     <groupId>com.forgerock.openbanking.clients</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-clients</artifactId>
-    <version>1.2.7-SNAPSHOT</version>
+    <version>1.2.7</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -99,7 +99,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-clients.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-clients.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-clients.git</url>
-        <tag>HEAD</tag>
+        <tag>1.2.7</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - Clients</name>
     <groupId>com.forgerock.openbanking.clients</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-clients</artifactId>
-    <version>1.2.7</version>
+    <version>1.2.8-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -99,7 +99,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-clients.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-clients.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-clients.git</url>
-        <tag>1.2.7</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
Use v 1.2.7 of openbanking commons 
https://github.com/OpenBankingToolkit/openbanking-common/releases/tag/1.2.7

Fixes;
Serialisation is based on the value of the `iss` field of the software
statement, and the code expected OpenBanking iss to be "OpenBanking",
however in OB Directory Issued Software Statements the iss field is
actually "OpenBanking Ltd"

Issue: https://github.com/ForgeCloud/ob-deploy/issues/793