### PR TITLE
793: Fix more issues with DirectorySoftwareStatement serialisation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <url>http://www.forgerock.org</url>
 
     <properties>
-        <ob-common.version>1.2.8</ob-common.version>
+        <ob-common.version>1.2.9</ob-common.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Use latest commons with fix to ensure `iss` field is visible in DirectorySoftwareStatement serialisation.
Also includes fix to add iss field to SoftwareStatement issued by the Directory Server.

Includes https://github.com/OpenBankingToolkit/openbanking-common/pull/140