### PR TITLE
Release 1.2.10 with 796: add matls checks to dcr code

### DIFF
--- a/forgerock-openbanking-analytics-client/pom.xml
+++ b/forgerock-openbanking-analytics-client/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.clients</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-clients</artifactId>
-        <version>1.2.10-SNAPSHOT</version>
+        <version>1.2.10</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-analytics-client/pom.xml
+++ b/forgerock-openbanking-analytics-client/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.clients</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-clients</artifactId>
-        <version>1.2.10</version>
+        <version>1.2.11-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-analytics-webclient/pom.xml
+++ b/forgerock-openbanking-analytics-webclient/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <artifactId>forgerock-openbanking-reference-implementation-clients</artifactId>
         <groupId>com.forgerock.openbanking.clients</groupId>
-        <version>1.2.10-SNAPSHOT</version>
+        <version>1.2.10</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-analytics-webclient/pom.xml
+++ b/forgerock-openbanking-analytics-webclient/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <artifactId>forgerock-openbanking-reference-implementation-clients</artifactId>
         <groupId>com.forgerock.openbanking.clients</groupId>
-        <version>1.2.10</version>
+        <version>1.2.11-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-client/pom.xml
+++ b/forgerock-openbanking-jwkms-client/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.clients</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-clients</artifactId>
-        <version>1.2.10-SNAPSHOT</version>
+        <version>1.2.10</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-client/pom.xml
+++ b/forgerock-openbanking-jwkms-client/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.clients</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-clients</artifactId>
-        <version>1.2.10</version>
+        <version>1.2.11-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - Clients</name>
     <groupId>com.forgerock.openbanking.clients</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-clients</artifactId>
-    <version>1.2.10-SNAPSHOT</version>
+    <version>1.2.10</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -99,7 +99,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-clients.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-clients.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-clients.git</url>
-        <tag>HEAD</tag>
+        <tag>1.2.10</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - Clients</name>
     <groupId>com.forgerock.openbanking.clients</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-clients</artifactId>
-    <version>1.2.10</version>
+    <version>1.2.11-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -99,7 +99,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-clients.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-clients.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-clients.git</url>
-        <tag>1.2.10</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <url>http://www.forgerock.org</url>
 
     <properties>
-        <ob-common.version>1.2.9</ob-common.version>
+        <ob-common.version>1.2.10</ob-common.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Release 2.1.10

796: Add MATLS checks to DCR code

Common code needed to perform MATLS checks to ensure the MATLS transport
cert presented for registration and the software statement being used
for registration were issed to the same ApiClient (TPP)

Issue: https://github.com/ForgeCloud/ob-deploy/issues/796