### PR TITLE
45: Use latest parent with uk-datamodel with 3.1.8r5 models

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-parent</artifactId>
-        <version>1.2.4</version>
+        <version>1.2.5</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 


### PR DESCRIPTION
Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/45