### PR TITLE
45: Release 1.2.14 to Use fixed uk-datamodel for 3.1.8

### DIFF
--- a/forgerock-openbanking-analytics-client/pom.xml
+++ b/forgerock-openbanking-analytics-client/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.clients</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-clients</artifactId>
-        <version>1.2.14</version>
+        <version>1.2.15-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-analytics-client/pom.xml
+++ b/forgerock-openbanking-analytics-client/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.clients</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-clients</artifactId>
-        <version>1.2.14-SNAPSHOT</version>
+        <version>1.2.14</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-analytics-webclient/pom.xml
+++ b/forgerock-openbanking-analytics-webclient/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <artifactId>forgerock-openbanking-reference-implementation-clients</artifactId>
         <groupId>com.forgerock.openbanking.clients</groupId>
-        <version>1.2.14-SNAPSHOT</version>
+        <version>1.2.14</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-analytics-webclient/pom.xml
+++ b/forgerock-openbanking-analytics-webclient/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <artifactId>forgerock-openbanking-reference-implementation-clients</artifactId>
         <groupId>com.forgerock.openbanking.clients</groupId>
-        <version>1.2.14</version>
+        <version>1.2.15-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-client/pom.xml
+++ b/forgerock-openbanking-jwkms-client/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.clients</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-clients</artifactId>
-        <version>1.2.14</version>
+        <version>1.2.15-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-client/pom.xml
+++ b/forgerock-openbanking-jwkms-client/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.clients</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-clients</artifactId>
-        <version>1.2.14-SNAPSHOT</version>
+        <version>1.2.14</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - Clients</name>
     <groupId>com.forgerock.openbanking.clients</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-clients</artifactId>
-    <version>1.2.14</version>
+    <version>1.2.15-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -99,7 +99,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-clients.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-clients.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-clients.git</url>
-        <tag>1.2.14</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-parent</artifactId>
-        <version>1.2.5</version>
+        <version>1.2.6</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 
@@ -44,7 +44,7 @@
     <url>http://www.forgerock.org</url>
 
     <properties>
-        <ob-common.version>1.2.12</ob-common.version>
+        <ob-common.version>1.2.14</ob-common.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - Clients</name>
     <groupId>com.forgerock.openbanking.clients</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-clients</artifactId>
-    <version>1.2.14-SNAPSHOT</version>
+    <version>1.2.14</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -99,7 +99,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-clients.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-clients.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-clients.git</url>
-        <tag>HEAD</tag>
+        <tag>1.2.14</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
OBFundsConfirmationConsentResponse1Data uses OBExternalRequestStatus1Code rather than the StatusEnum
defined within the class.

Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/45